### PR TITLE
Consolidated download command

### DIFF
--- a/ci/tasks/add-version.yaml
+++ b/ci/tasks/add-version.yaml
@@ -8,6 +8,8 @@ params:
   CSP_API_TOKEN: ((marketplace_api_token))
   MARKETPLACE_ENV:
   PRODUCT_SLUG:
+  MKPCLI_DEBUG: true
+  MKPCLI_DEBUG_REQUEST_PAYLOADS: true
 
 inputs:
   - name: version
@@ -19,9 +21,9 @@ run:
     - |
       export VERSION=$(cat version/version)
 
-      mkpcli product list-versions --debug --debug-request-payloads --product "${PRODUCT_SLUG}" | grep "${VERSION}"
+      mkpcli product list-versions --product "${PRODUCT_SLUG}" | grep "${VERSION}"
       if [[ $? -ne 0 ]] ; then
         set -e
-        mkpcli product add-version --debug --debug-request-payloads --product "${PRODUCT_SLUG}" --product-version "${VERSION}"
-        mkpcli product list-versions --debug --debug-request-payloads --product "${PRODUCT_SLUG}" | grep "${VERSION}"
+        mkpcli product add-version --product "${PRODUCT_SLUG}" --product-version "${VERSION}"
+        mkpcli product list-versions --product "${PRODUCT_SLUG}" | grep "${VERSION}"
       fi

--- a/ci/tasks/download-chart.sh
+++ b/ci/tasks/download-chart.sh
@@ -11,8 +11,8 @@ if [ -z "${PRODUCT_SLUG}" ] ; then
 fi
 
 # Get the ID for the first chart
-CHARTS=$(mkpcli chart list --debug --debug-request-payloads --product "${PRODUCT_SLUG}" --product-version "${PRODUCT_VERSION}" --output json)
-CHART_ID=$(echo "${CHARTS}" | jq -r .[0].id)
+CHARTS=$(mkpcli chart list --product "${PRODUCT_SLUG}" --product-version "${PRODUCT_VERSION}" --output json)
+CHART_NAME=$(echo "${CHARTS}" | jq -r .[0].name)
 IS_IN_MKP_REGISTRY=$(echo "${CHARTS}" | jq -r .[0].isupdatedinmarketplaceregistry)
 PROCESSING_ERROR=$(echo "${CHARTS}" | jq -r .[0].processingerror)
 
@@ -22,9 +22,8 @@ done
 
 if [ "${IS_IN_MKP_REGISTRY}" == "true" ] ; then
   # Download the chart
-  mkpcli chart download --debug --debug-request-payloads \
-    --product "${PRODUCT_SLUG}" --product-version "${PRODUCT_VERSION}" \
-    --chart-id "${CHART_ID}" \
+  mkpcli download --product "${PRODUCT_SLUG}" --product-version "${PRODUCT_VERSION}" \
+    --filter "${CHART_NAME}" \
     --filename my-chart.tgz
 
   # Downloaded file is a real Helm chart

--- a/ci/tasks/download-chart.yaml
+++ b/ci/tasks/download-chart.yaml
@@ -9,6 +9,8 @@ params:
   MARKETPLACE_ENV:
   PRODUCT_SLUG:
   PRODUCT_VERSION:
+  MKPCLI_DEBUG: true
+  MKPCLI_DEBUG_REQUEST_PAYLOADS: true
 
 inputs:
   - name: source

--- a/ci/tasks/download-container-image.sh
+++ b/ci/tasks/download-container-image.sh
@@ -11,7 +11,7 @@ if [ -z "${PRODUCT_SLUG}" ] ; then
 fi
 
 # Get the ID for the first container image
-IMAGES=$(mkpcli container-image list --debug --debug-request-payloads --product "${PRODUCT_SLUG}" --product-version "${PRODUCT_VERSION}" --output json)
+IMAGES=$(mkpcli container-image list --product "${PRODUCT_SLUG}" --product-version "${PRODUCT_VERSION}" --output json)
 IMAGE_URL=$(echo "${IMAGES}" | jq -r .dockerurlsList[0].url)
 IMAGE_TAG=$(echo "${IMAGES}" | jq -r .dockerurlsList[0].imagetagsList[0].tag)
 IS_IN_MKP_REGISTRY=$(echo "${IMAGES}" | jq -r .dockerurlsList[0].imagetagsList[0].isupdatedinmarketplaceregistry)
@@ -23,9 +23,8 @@ done
 
 if [ "${IS_IN_MKP_REGISTRY}" == "true" ] && [ -z "${PROCESSING_ERROR}" ] ; then
   # Download the image
-  mkpcli container-image download --debug --debug-request-payloads \
-    --product "${PRODUCT_SLUG}" --product-version "${PRODUCT_VERSION}" \
-    --image-repository "${IMAGE_URL}" --tag "${IMAGE_TAG}" \
+  mkpcli download --product "${PRODUCT_SLUG}" --product-version "${PRODUCT_VERSION}" \
+    --filter "${IMAGE_URL}:${IMAGE_TAG}" \
     --filename my-container-image.tar
 
   # Downloaded file is a real docker image

--- a/ci/tasks/download-container-image.yaml
+++ b/ci/tasks/download-container-image.yaml
@@ -9,6 +9,8 @@ params:
   MARKETPLACE_ENV:
   PRODUCT_SLUG:
   PRODUCT_VERSION:
+  MKPCLI_DEBUG: true
+  MKPCLI_DEBUG_REQUEST_PAYLOADS: true
 
 inputs:
   - name: source

--- a/ci/tasks/download-vm.sh
+++ b/ci/tasks/download-vm.sh
@@ -10,20 +10,15 @@ if [ -z "${PRODUCT_SLUG}" ] ; then
   exit 1
 fi
 
-# Get the ID for the first chart
-FILES=$(mkpcli vm list --debug --debug-request-payloads --product "${PRODUCT_SLUG}" --product-version "${PRODUCT_VERSION}" --output json)
-FILE_ID=$(echo "${FILES}" | jq -r .[0].fileid)
+# Get the name for the first vm
+FILES=$(mkpcli vm list --product "${PRODUCT_SLUG}" --product-version "${PRODUCT_VERSION}" --output json)
+FILE_NAME=$(echo "${FILES}" | jq -r .[0].filename)
 STATUS=$(echo "${FILES}" | jq -r .[0].status)
-
-#while [ "${VALIDATION_STATUS}" == "pending" ] && [ -z "${PROCESSING_ERROR}" ] ; do
-#  sleep 60
-#done
 
 if [ "${STATUS}" == "APPROVAL_PENDING" ] || [ "${STATUS}" == "ACTIVE" ] ; then
   # Download the file
-  mkpcli vm download --debug --debug-request-payloads \
-    --product "${PRODUCT_SLUG}" --product-version "${PRODUCT_VERSION}" \
-    --file-id "${FILE_ID}" \
+  mkpcli vm download --product "${PRODUCT_SLUG}" --product-version "${PRODUCT_VERSION}" \
+    --filter "${FILE_NAME}" \
     --filename my-file
 
   # Downloaded virtual machine file is a real file

--- a/ci/tasks/download-vm.yaml
+++ b/ci/tasks/download-vm.yaml
@@ -9,6 +9,8 @@ params:
   MARKETPLACE_ENV:
   PRODUCT_SLUG:
   PRODUCT_VERSION:
+  MKPCLI_DEBUG: true
+  MKPCLI_DEBUG_REQUEST_PAYLOADS: true
 
 inputs:
   - name: source

--- a/ci/tasks/test-chart-product.yaml
+++ b/ci/tasks/test-chart-product.yaml
@@ -8,6 +8,8 @@ params:
   CSP_API_TOKEN: ((marketplace_api_token))
   MARKETPLACE_ENV:
   PRODUCT_SLUG:
+  MKPCLI_DEBUG: true
+  MKPCLI_DEBUG_REQUEST_PAYLOADS: true
 
 inputs:
   - name: version
@@ -22,14 +24,11 @@ run:
       VERSION=$(cat version/version)
 
       # Get the list of charts
-      mkpcli chart list --debug --debug-request-payloads \
-        --product "${PRODUCT_SLUG}" --product-version "${VERSION}"
+      mkpcli chart list --product "${PRODUCT_SLUG}" --product-version "${VERSION}"
 
       # Upload a chart
-      mkpcli chart attach --debug --debug-request-payloads \
-        --product "${PRODUCT_SLUG}" --product-version "${VERSION}" \
+      mkpcli chart attach --product "${PRODUCT_SLUG}" --product-version "${VERSION}" \
         --chart chart/*.tgz --readme "helm install it"
 
       # Get the list of charts
-      mkpcli chart list --debug --debug-request-payloads \
-        --product "${PRODUCT_SLUG}" --product-version "${VERSION}" | grep -v "Total count: 0"
+      mkpcli chart list --product "${PRODUCT_SLUG}" --product-version "${VERSION}" | grep -v "Total count: 0"

--- a/ci/tasks/test-container-image-product.yaml
+++ b/ci/tasks/test-container-image-product.yaml
@@ -10,6 +10,8 @@ params:
   PRODUCT_SLUG:
   TEST_IMAGE_REPO: bitnami/nginx
   TEST_IMAGE_TAG: 1.21.1
+  MKPCLI_DEBUG: true
+  MKPCLI_DEBUG_REQUEST_PAYLOADS: true
 
 inputs:
   - name: version
@@ -23,15 +25,12 @@ run:
       VERSION=$(cat version/version)
 
       # Get the list of container images
-      mkpcli container-image list --debug --debug-request-payloads \
-        --product "${PRODUCT_SLUG}" --product-version "${VERSION}"
+      mkpcli container-image list --product "${PRODUCT_SLUG}" --product-version "${VERSION}"
 
       # Upload a docker image
-      mkpcli container-image attach --debug --debug-request-payloads \
-        --product "${PRODUCT_SLUG}" --product-version "${VERSION}" \
+      mkpcli container-image attach --product "${PRODUCT_SLUG}" --product-version "${VERSION}" \
         --image-repository "${TEST_IMAGE_REPO}" --tag "${TEST_IMAGE_TAG}" --tag-type FIXED \
         --deployment-instructions "docker run ${TEST_IMAGE_REPO}:${TEST_IMAGE_TAG}"
 
       # Get the list of container images
-      mkpcli container-image list --debug --debug-request-payloads \
-        --product "${PRODUCT_SLUG}" --product-version "${VERSION}" | grep "${TEST_IMAGE_REPO} *${TEST_IMAGE_TAG}"
+      mkpcli container-image list --product "${PRODUCT_SLUG}" --product-version "${VERSION}" | grep "${TEST_IMAGE_REPO} *${TEST_IMAGE_TAG}"

--- a/ci/tasks/test-vm-product.yaml
+++ b/ci/tasks/test-vm-product.yaml
@@ -8,6 +8,8 @@ params:
   CSP_API_TOKEN: ((marketplace_api_token))
   MARKETPLACE_ENV:
   PRODUCT_SLUG:
+  MKPCLI_DEBUG: true
+  MKPCLI_DEBUG_REQUEST_PAYLOADS: true
 
 inputs:
   - name: version
@@ -23,14 +25,11 @@ run:
       VM_FILE=$(find vm -type f -name '*.iso' -or -name '*.ova')
 
       # Get the list of virtual machine files
-      mkpcli vm list --debug --debug-request-payloads \
-        --product "${PRODUCT_SLUG}" --product-version "${VERSION}"
+      mkpcli vm list --product "${PRODUCT_SLUG}" --product-version "${VERSION}"
 
       # Attach a virtual machine file
-      mkpcli vm attach --debug --debug-request-payloads \
-        --product "${PRODUCT_SLUG}" --product-version "${VERSION}" \
+      mkpcli vm attach --product "${PRODUCT_SLUG}" --product-version "${VERSION}" \
         --file "${VM_FILE}"
 
       # Get the list of virtual machine files
-      mkpcli vm list --debug --debug-request-payloads \
-        --product "${PRODUCT_SLUG}" --product-version "${VERSION}" | grep -v "Total count: 0"
+      mkpcli vm list --product "${PRODUCT_SLUG}" --product-version "${VERSION}" | grep -v "Total count: 0"

--- a/cmd/container_image.go
+++ b/cmd/container_image.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vmware-labs/marketplace-cli/v2/internal/models"
-	"github.com/vmware-labs/marketplace-cli/v2/pkg"
 )
 
 const (
@@ -21,7 +20,6 @@ var (
 	ContainerImageProductSlug            string
 	ContainerImageProductVersion         string
 	ContainerImageDeploymentInstructions string
-	downloadedContainerImageFilename     string
 	ImageRepository                      string
 	ImageTag                             string
 	ImageTagType                         string
@@ -31,7 +29,6 @@ func init() {
 	rootCmd.AddCommand(ContainerImageCmd)
 	ContainerImageCmd.AddCommand(ListContainerImageCmd)
 	ContainerImageCmd.AddCommand(GetContainerImageCmd)
-	ContainerImageCmd.AddCommand(DownloadContainerImageCmd)
 	ContainerImageCmd.AddCommand(AttachContainerImageCmd)
 
 	ListContainerImageCmd.Flags().StringVarP(&ContainerImageProductSlug, "product", "p", "", "Product slug (required)")
@@ -42,13 +39,6 @@ func init() {
 	_ = GetContainerImageCmd.MarkFlagRequired("product")
 	GetContainerImageCmd.Flags().StringVarP(&ContainerImageProductVersion, "product-version", "v", "", "Product version (default to latest version)")
 	GetContainerImageCmd.Flags().StringVarP(&ImageRepository, "image-repository", "r", "", "container repository")
-
-	DownloadContainerImageCmd.Flags().StringVarP(&ContainerImageProductSlug, "product", "p", "", "Product slug (required)")
-	_ = DownloadContainerImageCmd.MarkFlagRequired("product")
-	DownloadContainerImageCmd.Flags().StringVarP(&ContainerImageProductVersion, "product-version", "v", "", "Product version (default to latest version)")
-	DownloadContainerImageCmd.Flags().StringVarP(&ImageRepository, "image-repository", "r", "", "container image repository to download (required if product has multiple container images attached)")
-	DownloadContainerImageCmd.Flags().StringVar(&ImageTag, "tag", "", "container image tag (required if container image has multiple tags)")
-	DownloadContainerImageCmd.Flags().StringVarP(&downloadedContainerImageFilename, "filename", "f", "image.tar", "output file name")
 
 	AttachContainerImageCmd.Flags().StringVarP(&ContainerImageProductSlug, "product", "p", "", "Product slug (required)")
 	_ = AttachContainerImageCmd.MarkFlagRequired("product")
@@ -69,7 +59,7 @@ var ContainerImageCmd = &cobra.Command{
 	Short:     "List and manage container images attached to a product",
 	Long:      "List and manage container images attached to a product in the VMware Marketplace",
 	Args:      cobra.OnlyValidArgs,
-	ValidArgs: []string{ListContainerImageCmd.Use, GetContainerImageCmd.Use, DownloadContainerImageCmd.Use, AttachContainerImageCmd.Use},
+	ValidArgs: []string{ListContainerImageCmd.Use, GetContainerImageCmd.Use, AttachContainerImageCmd.Use},
 }
 
 var ListContainerImageCmd = &cobra.Command{
@@ -125,69 +115,6 @@ var GetContainerImageCmd = &cobra.Command{
 		}
 
 		return Output.RenderContainerImage(containerImage)
-	},
-}
-
-var DownloadContainerImageCmd = &cobra.Command{
-	Use:   "download",
-	Short: "Download a container image",
-	Long:  "Downloads a container image attached to a product in the VMware Marketplace",
-	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
-		product, version, err := Marketplace.GetProductWithVersion(ContainerImageProductSlug, ContainerImageProductVersion)
-		if err != nil {
-			return err
-		}
-
-		containerImages := product.GetContainerImagesForVersion(version.Number)
-		if containerImages == nil {
-			return fmt.Errorf("%s %s does not have any container images\n", product.Slug, version.Number)
-		}
-
-		var containerImage *models.DockerURLDetails
-		if ImageRepository != "" {
-			containerImage = containerImages.GetImage(ImageRepository)
-			if containerImage == nil {
-				return fmt.Errorf("%s %s does not have the container image \"%s\"", ContainerImageProductSlug, version.Number, ImageRepository)
-			}
-		} else {
-			if len(containerImages.DockerURLs) == 0 {
-				return fmt.Errorf("no container images found for %s %s", ContainerImageProductSlug, version.Number)
-			} else if len(containerImages.DockerURLs) == 1 {
-				containerImage = containerImages.DockerURLs[0]
-			} else {
-				return fmt.Errorf("multiple container images found for %s %s, please use the --image-repository parameter", ContainerImageProductSlug, version.Number)
-			}
-		}
-
-		var imageTag *models.DockerImageTag
-		if ImageTag != "" {
-			imageTag = containerImage.GetTag(ImageTag)
-			if imageTag == nil {
-				return fmt.Errorf("%s %s does not have the an image tag \"%s\" for %s", ContainerImageProductSlug, version.Number, ImageTag, containerImage.Url)
-			}
-		} else {
-			if len(containerImage.ImageTags) == 0 {
-				return fmt.Errorf("no tags images found for %s in %s %s", containerImage.Url, ContainerImageProductSlug, version.Number)
-			} else if len(containerImages.DockerURLs) == 1 {
-				imageTag = containerImage.ImageTags[0]
-			} else {
-				return fmt.Errorf("multiple tags found for %s in %s %s, please use the --tag parameter", containerImage.Url, ContainerImageProductSlug, version.Number)
-			}
-		}
-
-		if !imageTag.IsUpdatedInMarketplaceRegistry {
-			return fmt.Errorf("%s with tag %s in %s %s is not downloadable: %s", containerImage.Url, imageTag.Tag, ContainerImageProductSlug, version.Number, imageTag.ProcessingError)
-		}
-
-		return Marketplace.Download(product.ProductId, downloadedContainerImageFilename, &pkg.DownloadRequestPayload{
-			DockerlinkVersionID: containerImages.ID,
-			DockerUrlId:         containerImage.ID,
-			ImageTagId:          containerImage.ImageTags[0].ID,
-			AppVersion:          containerImages.AppVersion,
-			EulaAccepted:        true,
-		})
 	},
 }
 

--- a/cmd/container_image_test.go
+++ b/cmd/container_image_test.go
@@ -17,7 +17,6 @@ import (
 	. "github.com/onsi/gomega/gbytes"
 	"github.com/vmware-labs/marketplace-cli/v2/cmd"
 	"github.com/vmware-labs/marketplace-cli/v2/cmd/output/outputfakes"
-	"github.com/vmware-labs/marketplace-cli/v2/internal/models"
 	"github.com/vmware-labs/marketplace-cli/v2/pkg"
 	"github.com/vmware-labs/marketplace-cli/v2/pkg/pkgfakes"
 	"github.com/vmware-labs/marketplace-cli/v2/test"
@@ -201,14 +200,10 @@ var _ = Describe("ContainerImage", func() {
 				Expect(output.RenderContainerImageCallCount()).To(Equal(1))
 				containerImage := output.RenderContainerImageArgsForCall(0)
 				Expect(containerImage.Url).To(Equal("myId"))
-				Expect(containerImage.ImageTags).To(ContainElement(&models.DockerImageTag{
-					Tag:  "0.0.1",
-					Type: "FIXED",
-				}))
-				Expect(containerImage.ImageTags).To(ContainElement(&models.DockerImageTag{
-					Tag:  "latest",
-					Type: "FLOATING",
-				}))
+				Expect(containerImage.ImageTags[0].Tag).To(Equal("0.0.1"))
+				Expect(containerImage.ImageTags[0].Type).To(Equal("FIXED"))
+				Expect(containerImage.ImageTags[1].Tag).To(Equal("latest"))
+				Expect(containerImage.ImageTags[1].Type).To(Equal("FLOATING"))
 			})
 		})
 

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -1,0 +1,75 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/vmware-labs/marketplace-cli/v2/pkg"
+)
+
+var (
+	DownloadProductSlug    string
+	DownloadProductVersion string
+	DownloadFilter         string
+	DownloadFilename       string
+)
+
+func init() {
+	rootCmd.AddCommand(DownloadCmd)
+
+	DownloadCmd.Flags().StringVarP(&DownloadProductSlug, "product", "p", "", "Product slug (required)")
+	_ = DownloadCmd.MarkFlagRequired("product")
+	DownloadCmd.Flags().StringVarP(&DownloadProductVersion, "product-version", "v", "", "Product version (default to latest version)")
+	DownloadCmd.Flags().StringVar(&DownloadFilter, "filter", "", "filter to select from multiple files")
+	DownloadCmd.Flags().StringVarP(&DownloadFilename, "filename", "f", "", "output file name")
+
+}
+
+var DownloadCmd = &cobra.Command{
+	Use:   "download",
+	Short: "Download an asset from a product",
+	Long:  "Download an asset attached to a product in the VMware Marketplace",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		product, version, err := Marketplace.GetProductWithVersion(DownloadProductSlug, DownloadProductVersion)
+		if err != nil {
+			return err
+		}
+
+		var asset *pkg.Asset
+		assets := pkg.GetAssets(product, version.Number)
+		if len(assets) == 0 {
+			return fmt.Errorf("product %s %s does not have any downloadable assets", product.Slug, version.Number)
+		} else if len(assets) > 1 {
+			if DownloadFilter == "" {
+				return fmt.Errorf("product %s %s has multiple downloadable assets, please use the --filter parameter", product.Slug, version.Number)
+			} else {
+				for _, potentialAsset := range assets {
+					if strings.Contains(potentialAsset.Filename, DownloadFilter) {
+						if asset == nil {
+							asset = potentialAsset
+						} else {
+							return fmt.Errorf("product %s %s has multiple downloadable assets that match the filter \"%s\", please adjust the --filter parameter", product.Slug, version.Number, DownloadFilter)
+						}
+					}
+				}
+				if asset == nil {
+					return fmt.Errorf("product %s %s does not have any downloadable assets that match the filter \"%s\", please adjust the --filter parameter", product.Slug, version.Number, DownloadFilter)
+				}
+			}
+		} else {
+			asset = assets[0]
+		}
+
+		filename := asset.Filename
+		if DownloadFilename != "" {
+			filename = DownloadFilename
+		}
+		return Marketplace.Download(product.ProductId, filename, asset.DownloadRequestPayload)
+	},
+}

--- a/cmd/output/encoded_output.go
+++ b/cmd/output/encoded_output.go
@@ -9,6 +9,7 @@ import (
 	"io"
 
 	"github.com/vmware-labs/marketplace-cli/v2/internal/models"
+	"github.com/vmware-labs/marketplace-cli/v2/pkg"
 	"gopkg.in/yaml.v2"
 )
 
@@ -79,6 +80,10 @@ func (o *EncodedOutput) RenderFile(file *models.ProductDeploymentFile) error {
 
 func (o *EncodedOutput) RenderFiles(files []*models.ProductDeploymentFile) error {
 	return o.Print(files)
+}
+
+func (o *EncodedOutput) RenderAssets(assets []*pkg.Asset) error {
+	return o.Print(assets)
 }
 
 func (o *EncodedOutput) RenderSubscriptions(subscriptions []*models.Subscription) error {

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -5,6 +5,7 @@ package output
 
 import (
 	"github.com/vmware-labs/marketplace-cli/v2/internal/models"
+	"github.com/vmware-labs/marketplace-cli/v2/pkg"
 )
 
 const (
@@ -28,6 +29,8 @@ type Format interface {
 	RenderContainerImages(images *models.DockerVersionList) error
 	RenderFile(file *models.ProductDeploymentFile) error
 	RenderFiles(files []*models.ProductDeploymentFile) error
+
+	RenderAssets(assets []*pkg.Asset) error
 
 	RenderSubscriptions(subscriptions []*models.Subscription) error
 }

--- a/cmd/output/outputfakes/fake_format.go
+++ b/cmd/output/outputfakes/fake_format.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/vmware-labs/marketplace-cli/v2/cmd/output"
 	"github.com/vmware-labs/marketplace-cli/v2/internal/models"
+	"github.com/vmware-labs/marketplace-cli/v2/pkg"
 )
 
 type FakeFormat struct {
@@ -13,6 +14,17 @@ type FakeFormat struct {
 	printHeaderMutex       sync.RWMutex
 	printHeaderArgsForCall []struct {
 		arg1 string
+	}
+	RenderAssetsStub        func([]*pkg.Asset) error
+	renderAssetsMutex       sync.RWMutex
+	renderAssetsArgsForCall []struct {
+		arg1 []*pkg.Asset
+	}
+	renderAssetsReturns struct {
+		result1 error
+	}
+	renderAssetsReturnsOnCall map[int]struct {
+		result1 error
 	}
 	RenderChartStub        func(*models.ChartVersion) error
 	renderChartMutex       sync.RWMutex
@@ -157,6 +169,71 @@ func (fake *FakeFormat) PrintHeaderArgsForCall(i int) string {
 	defer fake.printHeaderMutex.RUnlock()
 	argsForCall := fake.printHeaderArgsForCall[i]
 	return argsForCall.arg1
+}
+
+func (fake *FakeFormat) RenderAssets(arg1 []*pkg.Asset) error {
+	var arg1Copy []*pkg.Asset
+	if arg1 != nil {
+		arg1Copy = make([]*pkg.Asset, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.renderAssetsMutex.Lock()
+	ret, specificReturn := fake.renderAssetsReturnsOnCall[len(fake.renderAssetsArgsForCall)]
+	fake.renderAssetsArgsForCall = append(fake.renderAssetsArgsForCall, struct {
+		arg1 []*pkg.Asset
+	}{arg1Copy})
+	fake.recordInvocation("RenderAssets", []interface{}{arg1Copy})
+	fake.renderAssetsMutex.Unlock()
+	if fake.RenderAssetsStub != nil {
+		return fake.RenderAssetsStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.renderAssetsReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeFormat) RenderAssetsCallCount() int {
+	fake.renderAssetsMutex.RLock()
+	defer fake.renderAssetsMutex.RUnlock()
+	return len(fake.renderAssetsArgsForCall)
+}
+
+func (fake *FakeFormat) RenderAssetsCalls(stub func([]*pkg.Asset) error) {
+	fake.renderAssetsMutex.Lock()
+	defer fake.renderAssetsMutex.Unlock()
+	fake.RenderAssetsStub = stub
+}
+
+func (fake *FakeFormat) RenderAssetsArgsForCall(i int) []*pkg.Asset {
+	fake.renderAssetsMutex.RLock()
+	defer fake.renderAssetsMutex.RUnlock()
+	argsForCall := fake.renderAssetsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeFormat) RenderAssetsReturns(result1 error) {
+	fake.renderAssetsMutex.Lock()
+	defer fake.renderAssetsMutex.Unlock()
+	fake.RenderAssetsStub = nil
+	fake.renderAssetsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeFormat) RenderAssetsReturnsOnCall(i int, result1 error) {
+	fake.renderAssetsMutex.Lock()
+	defer fake.renderAssetsMutex.Unlock()
+	fake.RenderAssetsStub = nil
+	if fake.renderAssetsReturnsOnCall == nil {
+		fake.renderAssetsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.renderAssetsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeFormat) RenderChart(arg1 *models.ChartVersion) error {
@@ -784,6 +861,8 @@ func (fake *FakeFormat) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.printHeaderMutex.RLock()
 	defer fake.printHeaderMutex.RUnlock()
+	fake.renderAssetsMutex.RLock()
+	defer fake.renderAssetsMutex.RUnlock()
 	fake.renderChartMutex.RLock()
 	defer fake.renderChartMutex.RUnlock()
 	fake.renderChartsMutex.RLock()

--- a/internal/models/addon.go
+++ b/internal/models/addon.go
@@ -8,6 +8,7 @@ type AddOnFiles struct {
 	Name             string `json:"name"`
 	URL              string `json:"url"`
 	ImageType        string `json:"imagetype"`
+	Status           string `json:"status"`
 	DeploymentStatus string `json:"deploymentstatus"`
 	UploadedOn       int32  `json:"uploadedon"`
 	UploadedBy       string `json:"uploadedby"`

--- a/internal/models/container_image.go
+++ b/internal/models/container_image.go
@@ -1,0 +1,71 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package models
+
+type DockerImageTag struct {
+	ID                             string `json:"id,omitempty"`
+	Tag                            string `json:"tag,omitempty"`
+	Type                           string `json:"type,omitempty"`
+	IsUpdatedInMarketplaceRegistry bool   `json:"isupdatedinmarketplaceregistry"`
+	MarketplaceS3Link              string `json:"marketplaces3link"`
+	AppCheckReportLink             string `json:"appcheckreportlink"`
+	AppCheckSummaryPdfLink         string `json:"appchecksummarypdflink"`
+	S3TarBackupUrl                 string `json:"s3tarbackupurl"`
+	ProcessingError                string `json:"processingerror"`
+	DownloadCount                  int64  `json:"downloadcount"`
+	DownloadURL                    string `json:"downloadurl"`
+	HashAlgo                       int    `json:"hashalgo"`
+	HashDigest                     string `json:"hashdigest"`
+	Size                           int64  `json:"size,omitempty"`
+}
+
+type DockerURLDetails struct {
+	ID                    string            `json:"id,omitempty"`
+	Key                   string            `json:"key,omitempty"`
+	Url                   string            `json:"url,omitempty"`
+	MarketplaceUpdatedUrl string            `json:"marketplaceupdatedurl"`
+	ImageTags             []*DockerImageTag `json:"imagetagsList"`
+	ImageTagsAsJson       string            `json:"imagetagsasjson"`
+	DeploymentInstruction string            `json:"deploymentinstruction"`
+}
+
+func (d *DockerURLDetails) GetTag(tagName string) *DockerImageTag {
+	for _, tag := range d.ImageTags {
+		if tag.Tag == tagName {
+			return tag
+		}
+	}
+	return nil
+}
+
+func (d *DockerURLDetails) HasTag(tagName string) bool {
+	return d.GetTag(tagName) != nil
+}
+
+type DockerVersionList struct {
+	ID                    string              `json:"id,omitempty"`
+	AppVersion            string              `json:"appversion"`
+	DeploymentInstruction string              `json:"deploymentinstruction"`
+	DockerURLs            []*DockerURLDetails `json:"dockerurlsList"`
+	Status                string              `json:"status,omitempty"`
+	ImageTags             []*DockerImageTag   `json:"imagetagsList"`
+}
+
+func (l *DockerVersionList) GetImage(imageURL string) *DockerURLDetails {
+	for _, image := range l.DockerURLs {
+		if image.Url == imageURL {
+			return image
+		}
+	}
+	return nil
+}
+
+func (product *Product) GetContainerImagesForVersion(version string) *DockerVersionList {
+	for _, dockerVersionLink := range product.DockerLinkVersions {
+		if dockerVersionLink.AppVersion == product.GetVersion(version).Number {
+			return dockerVersionLink
+		}
+	}
+	return nil
+}

--- a/internal/models/metafile.go
+++ b/internal/models/metafile.go
@@ -30,10 +30,21 @@ type MetaFile struct {
 	GroupId    string            `json:"groupid"`
 	GroupName  string            `json:"groupname"`
 	FileType   string            `json:"filetype"`
-	Version    string            `json:"version"`
-	AppVersion string            `json:"appversion"`
+	Version    string            `json:"version"`    // Note: This is the version of this particular file...
+	AppVersion string            `json:"appversion"` // Note: and this is the associated Marketplace product version
 	Status     string            `json:"status"`
 	Objects    []*MetaFileObject `json:"metafileobjectsList"`
 	CreatedBy  string            `json:"createdby"`
 	CreatedOn  int32             `json:"createdon"`
+}
+
+func (product *Product) GetMetaFilesForVersion(version string) []*MetaFile {
+	var metafiles []*MetaFile
+	for _, metafile := range product.MetaFiles {
+		if metafile.AppVersion == product.GetVersion(version).Number {
+			metafiles = append(metafiles, metafile)
+		}
+	}
+
+	return metafiles
 }

--- a/internal/models/product_deployment_file.go
+++ b/internal/models/product_deployment_file.go
@@ -1,0 +1,54 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package models
+
+type ProductDeploymentFile struct {
+	Id              string   `json:"id,omitempty"` // uuid
+	Name            string   `json:"name,omitempty"`
+	Url             string   `json:"url,omitempty"`
+	ImageType       string   `json:"imagetype,omitempty"`
+	Status          string   `json:"status,omitempty"`
+	UploadedOn      int32    `json:"uploadedon,omitempty"`
+	UploadedBy      string   `json:"uploadedby,omitempty"`
+	UpdatedOn       int32    `json:"updatedon,omitempty"`
+	UpdatedBy       string   `json:"updatedby,omitempty"`
+	ItemJson        string   `json:"itemjson,omitempty"`
+	Itemkey         string   `json:"itemkey,omitempty"`
+	FileID          string   `json:"fileid,omitempty"`
+	IsSubscribed    bool     `json:"issubscribed,omitempty"`
+	AppVersion      string   `json:"appversion"` // Mandatory
+	HashDigest      string   `json:"hashdigest"`
+	IsThirdPartyUrl bool     `json:"isthirdpartyurl,omitempty"`
+	ThirdPartyUrl   string   `json:"thirdpartyurl,omitempty"`
+	IsRedirectUrl   bool     `json:"isredirecturl,omitempty"`
+	Comment         string   `json:"comment,omitempty"`
+	HashAlgo        string   `json:"hashalgo"`
+	DownloadCount   int64    `json:"downloadcount,omitempty"`
+	UniqueFileID    string   `json:"uniqueFileId,omitempty"`
+	VersionList     []string `json:"versionList"`
+	Size            int64    `json:"size,omitempty"`
+}
+
+func (product *Product) GetFilesForVersion(version string) []*ProductDeploymentFile {
+	var files []*ProductDeploymentFile
+	for _, file := range product.ProductDeploymentFiles {
+		if file.AppVersion == product.GetVersion(version).Number {
+			files = append(files, file)
+		}
+	}
+	return files
+}
+
+func (product *Product) GetFile(fileId string) *ProductDeploymentFile {
+	for _, file := range product.ProductDeploymentFiles {
+		if file.FileID == fileId {
+			return file
+		}
+	}
+	return nil
+}
+
+func (product *Product) AddFile(file *ProductDeploymentFile) {
+	product.ProductDeploymentFiles = append(product.ProductDeploymentFiles, file)
+}

--- a/internal/models/version.go
+++ b/internal/models/version.go
@@ -1,0 +1,112 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package models
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/coreos/go-semver/semver"
+)
+
+type Version struct {
+	Number           string `json:"versionnumber"`
+	Details          string `json:"versiondetails"`
+	Status           string `json:"status,omitempty"`
+	Instructions     string `json:"versioninstruction"`
+	CreatedOn        int32  `json:"createdon,omitempty"`
+	HasLimitedAccess bool   `json:"haslimitedaccess,omitempty"`
+	Tag              string `json:"tag,omitempty"`
+}
+
+func (product *Product) GetVersion(version string) *Version {
+	if version == "" {
+		return product.GetLatestVersion()
+	}
+
+	for _, v := range product.AllVersions {
+		if v.Number == version {
+			return v
+		}
+	}
+	return nil
+}
+
+func (product *Product) GetLatestVersion() *Version {
+	if len(product.AllVersions) == 0 {
+		return &Version{Number: "N/A"}
+	}
+
+	// TODO: use the new product.latestversion field instead?
+
+	version, err := product.getLatestVersionSemver()
+	if err != nil {
+		version = product.getLatestVersionAlphanumeric()
+	}
+
+	return version
+}
+
+func (product *Product) getLatestVersionSemver() (*Version, error) {
+	latestVersion := product.AllVersions[0]
+	version, err := semver.NewVersion(latestVersion.Number)
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range product.AllVersions {
+		otherVersion, err := semver.NewVersion(v.Number)
+		if err != nil {
+			return nil, err
+		}
+		if version.LessThan(*otherVersion) {
+			latestVersion = v
+			version = otherVersion
+		}
+	}
+
+	return latestVersion, nil
+}
+
+func (product *Product) getLatestVersionAlphanumeric() *Version {
+	latestVersion := product.AllVersions[0]
+	for _, v := range product.AllVersions {
+		if strings.Compare(latestVersion.Number, v.Number) < 0 {
+			latestVersion = v
+		}
+	}
+	return latestVersion
+}
+
+type Versions []*Version
+
+func (v Versions) Len() int {
+	return len(v)
+}
+
+func (v Versions) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}
+
+func (v Versions) Less(i, j int) bool {
+	return v[i].LessThan(*v[j])
+}
+
+func (a Version) LessThan(b Version) bool {
+	semverA, errA := semver.NewVersion(a.Number)
+	semverB, errB := semver.NewVersion(b.Number)
+
+	if errA != nil || errB != nil {
+		return strings.Compare(a.Number, b.Number) < 0
+	}
+
+	return semverA.LessThan(*semverB)
+}
+
+func Sort(versions []*Version) {
+	sort.Sort(sort.Reverse(Versions(versions)))
+}
+
+func (product *Product) HasVersion(version string) bool {
+	return product.GetVersion(version) != nil
+}

--- a/pkg/asset.go
+++ b/pkg/asset.go
@@ -1,0 +1,119 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package pkg
+
+import (
+	"fmt"
+
+	"github.com/vmware-labs/marketplace-cli/v2/internal/models"
+)
+
+type Asset struct {
+	DisplayName            string `json:"displayname"`
+	Filename               string `json:"filename"`
+	Version                string `json:"version"`
+	Type                   string `json:"type"`
+	Size                   int64  `json:"size"`
+	Downloadable           bool   `json:"downloadable"`
+	Downloads              int64  `json:"downloads"`
+	DownloadRequestPayload *DownloadRequestPayload
+}
+
+const (
+	AssetTypeVM             = "VM"
+	AssetTypeChart          = "Chart"
+	AssetTypeContainerImage = "Container Image"
+	AssetTypeMetaFile       = "MetaFile"
+)
+
+func GetAssets(product *models.Product, version string) []*Asset {
+	var assets []*Asset
+	if !product.HasVersion(version) {
+		return assets
+	}
+
+	for _, file := range product.GetFilesForVersion(version) {
+		assets = append(assets, &Asset{
+			DisplayName:  file.Name,
+			Filename:     file.Name,
+			Version:      "",
+			Type:         AssetTypeVM,
+			Size:         file.Size,
+			Downloads:    file.DownloadCount,
+			Downloadable: file.Status != models.DeploymentStatusInactive,
+			DownloadRequestPayload: &DownloadRequestPayload{
+				ProductId:        product.ProductId,
+				AppVersion:       version,
+				EulaAccepted:     true,
+				DeploymentFileId: file.FileID,
+			},
+		})
+	}
+
+	for _, chart := range product.GetChartsForVersion(version) {
+		assets = append(assets, &Asset{
+			DisplayName:  chart.Repo.Name,
+			Filename:     "chart.tgz",
+			Version:      chart.Version,
+			Type:         AssetTypeChart,
+			Size:         chart.Size,
+			Downloadable: chart.IsUpdatedInMarketplaceRegistry,
+			Downloads:    chart.DownloadCount,
+			DownloadRequestPayload: &DownloadRequestPayload{
+				ProductId:    product.ProductId,
+				AppVersion:   version,
+				EulaAccepted: true,
+				ChartVersion: chart.Version,
+			},
+		})
+	}
+
+	containerImages := product.GetContainerImagesForVersion(version)
+	if containerImages != nil {
+		for _, containerImage := range containerImages.DockerURLs {
+			for _, tag := range containerImage.ImageTags {
+				assets = append(assets, &Asset{
+					DisplayName:  fmt.Sprintf("%s:%s", containerImage.Url, tag.Tag),
+					Filename:     "image.tar",
+					Version:      tag.Tag,
+					Type:         AssetTypeContainerImage,
+					Size:         tag.Size,
+					Downloads:    tag.DownloadCount,
+					Downloadable: tag.IsUpdatedInMarketplaceRegistry,
+					DownloadRequestPayload: &DownloadRequestPayload{
+						ProductId:           product.ProductId,
+						AppVersion:          version,
+						EulaAccepted:        true,
+						DockerlinkVersionID: containerImages.ID,
+						DockerUrlId:         containerImage.ID,
+						ImageTagId:          tag.ID,
+					},
+				})
+			}
+		}
+	}
+
+	for _, metafile := range product.GetMetaFilesForVersion(version) {
+		for _, object := range metafile.Objects {
+			assets = append(assets, &Asset{
+				DisplayName:  object.FileName,
+				Filename:     object.FileName,
+				Version:      metafile.Version,
+				Type:         AssetTypeMetaFile,
+				Size:         object.Size,
+				Downloads:    object.DownloadCount,
+				Downloadable: object.IsFileBackedUp, // Is this valid?
+				DownloadRequestPayload: &DownloadRequestPayload{
+					ProductId:        product.ProductId,
+					AppVersion:       version,
+					EulaAccepted:     true,
+					MetaFileID:       metafile.ID,
+					MetaFileObjectID: object.FileID,
+				},
+			})
+		}
+	}
+
+	return assets
+}

--- a/pkg/asset_test.go
+++ b/pkg/asset_test.go
@@ -1,0 +1,163 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package pkg_test
+
+import (
+	"strconv"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vmware-labs/marketplace-cli/v2/internal/models"
+	"github.com/vmware-labs/marketplace-cli/v2/pkg"
+	"github.com/vmware-labs/marketplace-cli/v2/test"
+)
+
+var _ = Describe("Asset", func() {
+	Describe("GetAssets", func() {
+		Context("Chart", func() {
+			var (
+				product *models.Product
+				chart   *models.ChartVersion
+			)
+			BeforeEach(func() {
+				product = test.CreateFakeProduct("", "Hyperspace Database", "hyperspace-database", "PENDING")
+				test.AddVerions(product, "1")
+				chart = &models.ChartVersion{
+					Id:         uuid.New().String(),
+					Version:    "1.0.0",
+					AppVersion: "1",
+					Repo: &models.Repo{
+						Name: "hyperspace-database",
+					},
+					Size:                           5000,
+					DownloadCount:                  10,
+					IsUpdatedInMarketplaceRegistry: true,
+				}
+				product.AddChart(chart)
+			})
+
+			It("returns the container image", func() {
+				assets := pkg.GetAssets(product, "1")
+				Expect(assets).To(HaveLen(1))
+
+				Expect(assets[0].DisplayName).To(Equal("hyperspace-database"))
+				Expect(assets[0].Filename).To(Equal("chart.tgz"))
+				Expect(assets[0].Version).To(Equal("1.0.0"))
+				Expect(assets[0].Type).To(Equal("Chart"))
+				Expect(strconv.FormatInt(assets[0].Size, 10)).To(Equal("5000"))
+				Expect(strconv.FormatInt(assets[0].Downloads, 10)).To(Equal("10"))
+				Expect(assets[0].Downloadable).To(BeTrue())
+
+				Expect(assets[0].DownloadRequestPayload.ProductId).To(Equal(product.ProductId))
+				Expect(assets[0].DownloadRequestPayload.AppVersion).To(Equal("1"))
+				Expect(assets[0].DownloadRequestPayload.EulaAccepted).To(BeTrue())
+				Expect(assets[0].DownloadRequestPayload.ChartVersion).To(Equal("1.0.0"))
+			})
+		})
+
+		Context("Container image", func() {
+			var (
+				product        *models.Product
+				containerImage *models.DockerURLDetails
+			)
+			BeforeEach(func() {
+				product = test.CreateFakeProduct("", "Hyperspace Database", "hyperspace-database", "PENDING")
+				test.AddVerions(product, "1")
+				containerImage = test.CreateFakeContainerImage("astrowidgets/hyperspacedb", "1", "imaginary")
+				test.AddContainerImages(product, "1", "docker run it", containerImage)
+			})
+
+			It("returns the container image", func() {
+				assets := pkg.GetAssets(product, "1")
+				Expect(assets).To(HaveLen(2))
+
+				By("having an entry for each tag", func() {
+					Expect(assets[0].DisplayName).To(Equal("astrowidgets/hyperspacedb:1"))
+					Expect(assets[0].Filename).To(Equal("image.tar"))
+					Expect(assets[0].Version).To(Equal("1"))
+					Expect(assets[0].Type).To(Equal("Container Image"))
+					Expect(strconv.FormatInt(assets[0].Size, 10)).To(Equal("12345"))
+					Expect(strconv.FormatInt(assets[0].Downloads, 10)).To(Equal("15"))
+					Expect(assets[0].Downloadable).To(BeTrue())
+
+					Expect(assets[0].DownloadRequestPayload.ProductId).To(Equal(product.ProductId))
+					Expect(assets[0].DownloadRequestPayload.AppVersion).To(Equal("1"))
+					Expect(assets[0].DownloadRequestPayload.EulaAccepted).To(BeTrue())
+					Expect(assets[0].DownloadRequestPayload.DockerlinkVersionID).To(Equal(product.DockerLinkVersions[0].ID))
+					Expect(assets[0].DownloadRequestPayload.DockerUrlId).To(Equal(containerImage.ID))
+					Expect(assets[0].DownloadRequestPayload.ImageTagId).To(Equal(containerImage.ImageTags[0].ID))
+
+					Expect(assets[1].DisplayName).To(Equal("astrowidgets/hyperspacedb:imaginary"))
+					Expect(assets[1].Filename).To(Equal("image.tar"))
+					Expect(assets[1].Version).To(Equal("imaginary"))
+					Expect(assets[1].Type).To(Equal("Container Image"))
+					Expect(strconv.FormatInt(assets[1].Size, 10)).To(Equal("12345"))
+					Expect(strconv.FormatInt(assets[1].Downloads, 10)).To(Equal("15"))
+					Expect(assets[1].Downloadable).To(BeTrue())
+
+					Expect(assets[1].DownloadRequestPayload.ProductId).To(Equal(product.ProductId))
+					Expect(assets[1].DownloadRequestPayload.AppVersion).To(Equal("1"))
+					Expect(assets[1].DownloadRequestPayload.EulaAccepted).To(BeTrue())
+					Expect(assets[1].DownloadRequestPayload.DockerlinkVersionID).To(Equal(product.DockerLinkVersions[0].ID))
+					Expect(assets[1].DownloadRequestPayload.DockerUrlId).To(Equal(containerImage.ID))
+					Expect(assets[1].DownloadRequestPayload.ImageTagId).To(Equal(containerImage.ImageTags[1].ID))
+				})
+			})
+		})
+
+		Context("VM and MetaFile", func() {
+			var (
+				product  *models.Product
+				vm       *models.ProductDeploymentFile
+				metafile *models.MetaFile
+			)
+			BeforeEach(func() {
+				product = test.CreateFakeProduct("", "Hyperspace Database", "hyperspace-database", "PENDING")
+				test.AddVerions(product, "1")
+				vm = test.CreateFakeOVA("hyperspace-database.ova", "1")
+				product.ProductDeploymentFiles = append(product.ProductDeploymentFiles, vm)
+
+				metafile = test.CreateFakeMetaFile("deploy.sh", "0.0.1", "1")
+				product.MetaFiles = append(product.MetaFiles, metafile)
+			})
+
+			It("returns the aggregated list of attached assets", func() {
+				assets := pkg.GetAssets(product, "1")
+				Expect(assets).To(HaveLen(2))
+
+				By("including the VM file", func() {
+					Expect(assets[0].DisplayName).To(Equal("hyperspace-database.ova"))
+					Expect(assets[0].Filename).To(Equal("hyperspace-database.ova"))
+					Expect(assets[0].Version).To(BeEmpty())
+					Expect(assets[0].Type).To(Equal("VM"))
+					Expect(strconv.FormatInt(assets[0].Size, 10)).To(Equal("1000100"))
+					Expect(strconv.FormatInt(assets[0].Downloads, 10)).To(Equal("20"))
+					Expect(assets[0].Downloadable).To(BeTrue())
+
+					Expect(assets[0].DownloadRequestPayload.ProductId).To(Equal(product.ProductId))
+					Expect(assets[0].DownloadRequestPayload.AppVersion).To(Equal("1"))
+					Expect(assets[0].DownloadRequestPayload.EulaAccepted).To(BeTrue())
+					Expect(assets[0].DownloadRequestPayload.DeploymentFileId).To(Equal(vm.FileID))
+				})
+
+				By("including the meta file", func() {
+					Expect(assets[1].DisplayName).To(Equal("deploy.sh"))
+					Expect(assets[1].Filename).To(Equal("deploy.sh"))
+					Expect(assets[1].Version).To(Equal("0.0.1"))
+					Expect(assets[1].Type).To(Equal("MetaFile"))
+					Expect(strconv.FormatInt(assets[1].Size, 10)).To(Equal("123"))
+					Expect(strconv.FormatInt(assets[1].Downloads, 10)).To(Equal("25"))
+					Expect(assets[0].Downloadable).To(BeTrue())
+
+					Expect(assets[1].DownloadRequestPayload.ProductId).To(Equal(product.ProductId))
+					Expect(assets[1].DownloadRequestPayload.AppVersion).To(Equal("1"))
+					Expect(assets[1].DownloadRequestPayload.EulaAccepted).To(BeTrue())
+					Expect(assets[1].DownloadRequestPayload.MetaFileID).To(Equal(metafile.ID))
+					Expect(assets[1].DownloadRequestPayload.MetaFileObjectID).To(Equal(metafile.Objects[0].FileID))
+				})
+			})
+		})
+	})
+})

--- a/pkg/download.go
+++ b/pkg/download.go
@@ -17,15 +17,18 @@ import (
 )
 
 type DownloadRequestPayload struct {
+	ProductId           string `json:"productid,omitempty"`
+	AppVersion          string `json:"appVersion,omitempty"`
+	EulaAccepted        bool   `json:"eulaAccepted"`
 	DockerlinkVersionID string `json:"dockerlinkVersionId,omitempty"`
 	DockerUrlId         string `json:"dockerUrlId,omitempty"`
 	ImageTagId          string `json:"imageTagId,omitempty"`
 	DeploymentFileId    string `json:"deploymentFileId,omitempty"`
-	AppVersion          string `json:"appVersion,omitempty"`
 	ChartVersion        string `json:"chartVersion,omitempty"`
 	IsAddonFile         string `json:"isAddonFile,omitempty"`
 	AddonFileId         string `json:"addonFileId,omitempty"`
-	EulaAccepted        bool   `json:"eulaAccepted"`
+	MetaFileID          string `json:"metafileid,omitempty"`
+	MetaFileObjectID    string `json:"metafileobjectid,omitempty"`
 }
 
 type DownloadResponse struct {

--- a/test/common.go
+++ b/test/common.go
@@ -53,10 +53,13 @@ func CreateFakeOVA(name, version string) *models.ProductDeploymentFile {
 	Expect(err).ToNot(HaveOccurred())
 
 	return &models.ProductDeploymentFile{
-		AppVersion: version,
-		FileID:     uuid.New().String(),
-		Status:     "STORED",
-		ItemJson:   string(detailString),
+		FileID:        uuid.New().String(),
+		Name:          name,
+		Status:        models.DeploymentStatusActive,
+		ItemJson:      string(detailString),
+		AppVersion:    version,
+		Size:          1000100,
+		DownloadCount: 20,
 	}
 }
 
@@ -70,8 +73,12 @@ func CreateFakeContainerImage(url string, tags ...string) *models.DockerURLDetai
 		}
 
 		tagList = append(tagList, &models.DockerImageTag{
-			Tag:  tag,
-			Type: tagType,
+			ID:                             uuid.New().String(),
+			Tag:                            tag,
+			Type:                           tagType,
+			Size:                           12345,
+			DownloadCount:                  15,
+			IsUpdatedInMarketplaceRegistry: true,
 		})
 	}
 
@@ -79,6 +86,23 @@ func CreateFakeContainerImage(url string, tags ...string) *models.DockerURLDetai
 		ID:        uuid.New().String(),
 		Url:       url,
 		ImageTags: tagList,
+	}
+}
+
+func CreateFakeMetaFile(name, version, productVersion string) *models.MetaFile {
+	return &models.MetaFile{
+		ID:         uuid.New().String(),
+		FileType:   models.MetaFileTypeCLI,
+		Version:    version,
+		AppVersion: productVersion,
+		Objects: []*models.MetaFileObject{
+			{
+				FileName:       name,
+				Size:           123,
+				DownloadCount:  25,
+				IsFileBackedUp: true,
+			},
+		},
 	}
 }
 
@@ -101,7 +125,7 @@ func AddVerions(product *models.Product, versions ...string) *models.Product {
 
 func AddContainerImages(product *models.Product, version string, instructions string, images ...*models.DockerURLDetails) *models.Product {
 	imageList := &models.DockerVersionList{
-		ID:                    "",
+		ID:                    uuid.New().String(),
 		AppVersion:            version,
 		DeploymentInstruction: instructions,
 		DockerURLs:            []*models.DockerURLDetails{},

--- a/test/common_steps.go
+++ b/test/common_steps.go
@@ -54,4 +54,8 @@ func DefineCommonSteps(define Definitions, marketplaceEnvironment string) {
 	define.Then(`^the command exits without error$`, func() {
 		Eventually(CommandSession, time.Minute).Should(gexec.Exit(0))
 	})
+
+	define.Then(`^the command exits with an error$`, func() {
+		Eventually(CommandSession, time.Minute).Should(gexec.Exit(1))
+	})
 }

--- a/test/external/debugging_test.go
+++ b/test/external/debugging_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Debugging", func() {
 	})
 
 	Scenario("Debugging enabled with request payloads", func() {
-		steps.When("running mkpcli --debug --debug-request-payloads container-image download -p vmware-tanzu-rabbitmq1 -v 1.0.0")
+		steps.When("running mkpcli --debug --debug-request-payloads download -p vmware-tanzu-rabbitmq1 -v 1.0.0")
 		steps.Then("the command exits without error")
 		steps.And("the container image is downloaded")
 		steps.And("the requests are printed with request payloads")
@@ -40,7 +40,7 @@ var _ = Describe("Debugging", func() {
 	Scenario("Debugging enabled with request payloads with environment variables", func() {
 		steps.When("The environment variable MKPCLI_DEBUG is set to true")
 		steps.And("The environment variable MKPCLI_DEBUG_REQUEST_PAYLOADS is set to true")
-		steps.And("running mkpcli container-image download -p vmware-tanzu-rabbitmq1 -v 1.0.0")
+		steps.And("running mkpcli download -p vmware-tanzu-rabbitmq1 -v 1.0.0")
 		steps.Then("the command exits without error")
 		steps.And("the container image is downloaded")
 		steps.And("the requests are printed with request payloads")
@@ -54,6 +54,8 @@ var _ = Describe("Debugging", func() {
 			Eventually(CommandSession.Err).Should(Say("Request #0 Response: 200 OK"))
 			Eventually(CommandSession.Out).Should(Say("Name:      VMware Tanzu RabbitMQ"))
 			Eventually(CommandSession.Out).Should(Say("Publisher: VMware Inc"))
+			Eventually(CommandSession.Out).Should(Say("Assets for 1.0.0:"))
+			Eventually(CommandSession.Out).Should(Say("registry.pivotal.io/rabbitmq/vmware-tanzu-rabbitmq:2020.12"))
 		})
 
 		define.Then(`^the container image is downloaded$`, func() {
@@ -66,7 +68,7 @@ var _ = Describe("Debugging", func() {
 			Eventually(CommandSession.Err).Should(Say("Request #0 Response: 200 OK"))
 			Eventually(CommandSession.Err).Should(Say(regexp.QuoteMeta("Request #1: POST https://gtw.marketplace.cloud.vmware.com/api/v1/products/5f99a9d5-dbfd-4cfc-a564-b1a67d092b4f/download")))
 			Eventually(CommandSession.Err).Should(Say("--- Start of request #1 body payload ---"))
-			Eventually(CommandSession.Err).Should(Say(regexp.QuoteMeta("{\"dockerlinkVersionId\":\"d333021c-6e7d-4a15-b87a-2f66eda9d30c\",\"dockerUrlId\":\"f1702bcd-5634-4983-a652-653b6aedbe1d\",\"imageTagId\":\"83fa36ea-4ebc-4499-b68d-b95bc185dd65\",\"appVersion\":\"1.0.0\",\"eulaAccepted\":true}")))
+			Eventually(CommandSession.Err).Should(Say(regexp.QuoteMeta("{\"productid\":\"5f99a9d5-dbfd-4cfc-a564-b1a67d092b4f\",\"appVersion\":\"1.0.0\",\"eulaAccepted\":true,\"dockerlinkVersionId\":\"d333021c-6e7d-4a15-b87a-2f66eda9d30c\",\"dockerUrlId\":\"f1702bcd-5634-4983-a652-653b6aedbe1d\",\"imageTagId\":\"83fa36ea-4ebc-4499-b68d-b95bc185dd65\"}")))
 			Eventually(CommandSession.Err).Should(Say("--- End of request #1 body payload ---"))
 			Eventually(CommandSession.Err).Should(Say("Request #1 Response: 200 OK"))
 			Eventually(CommandSession.Err).Should(Say(regexp.QuoteMeta("Request #2: GET https://cmpprdcontainersolutions.s3.us-west-2.amazonaws.com/containerImageTars/")))

--- a/test/external/download_test.go
+++ b/test/external/download_test.go
@@ -1,0 +1,45 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package external_test
+
+import (
+	"os"
+
+	. "github.com/bunniesandbeatings/goerkin"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/vmware-labs/marketplace-cli/v2/test"
+)
+
+var _ = Describe("Download", func() {
+	steps := NewSteps()
+
+	Scenario("Downloading an asset", func() {
+		steps.When("running mkpcli download --product tanzu-kubenetes-grid-1 --product-version 1.4.0 --filter yq_linux_amd64 --filename yq")
+		steps.Then("the command exits without error")
+		steps.And("yq is downloaded")
+	})
+
+	Scenario("Download fails when there are multiple files", func() {
+		steps.When("running mkpcli download --product tanzu-kubenetes-grid-1 --product-version 1.4.0")
+		steps.Then("the command exits with an error")
+		steps.And("a message saying that there are multiple assets available to download")
+	})
+
+	steps.Define(func(define Definitions) {
+		DefineCommonSteps(define, "staging")
+
+		define.Then(`^yq is downloaded$`, func() {
+			_, err := os.Stat("yq")
+			Expect(err).ToNot(HaveOccurred())
+		}, func() {
+			_ = os.Remove("yq")
+		})
+
+		define.Then(`^a message saying that there are multiple assets available to download$`, func() {
+			Eventually(CommandSession.Err).Should(Say("product tanzu-kubenetes-grid-1 1.4.0 has multiple downloadable assets, please use the --filter parameter"))
+		})
+	})
+})


### PR DESCRIPTION
This creates a new `download` command that should work regardless of asset type.

It introduces a new structure, `Asset` that is generic for any downloadable type.

This PR is just FYI for now, remaining work:
1. Print the list of assets in `mkpcli product get`
2. Add unit tests as appropriate
3. Add external tests
4. Adjust pipeline download tests to use this
5. Remove the existing `mkpcli <asset> download` commands which are redundant now
